### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-#HeartBeats
+# HeartBeats
 Source code for an iOS app to draw heart beats by reading color changes using the device flash led and CoreGraphics.
 
-###Example
+### Example
 
 ![Alt text](https://raw.github.com/chroman/HeartBeats/master/demo.png "Demo")
 
-#Introduction
+# Introduction
   - Experimental project
 
-#Version
+# Version
 1.0
 
-##Improvements
+## Improvements
 * Measure Heart Rate
 
-##Supports
+## Supports
 * iOS 6.0 or later.
 * Xcode 4.6 (ARC enabled).
 * Required frameworks: UIKit, AVFoundation and CoreGraphics.
 
-#Contact
+# Contact
 <a href="https://twitter.com/chroman">Follow @chroman</a>
 
-#License
+# License
 
 Copyright (c) 2013 Christian Roman, Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
